### PR TITLE
Adding function to set row closed immediately without animation.

### DIFF
--- a/components/SwipeRow.js
+++ b/components/SwipeRow.js
@@ -167,6 +167,13 @@ class SwipeRow extends Component {
 		this.manuallySwipeRow(0);
 	}
 
+	/*
+	 * Closes the row immediately, without animation.
+	 */
+	setRowClosed() {
+		this.state.translateX.setValue(0);
+	}
+
 	manuallySwipeRow(toValue) {
 		Animated.spring(
 			this.state.translateX,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-swipe-list-view",
-  "version": "0.3.2",
+  "version": "0.3.5",
   "main": "lib/index.js",
   "author": "Jesse Sessler <jesse.sessler@gmail.com>",
   "description": "A ListView with rows that swipe open and closed.",


### PR DESCRIPTION
`.closeRow()` animates by default, taking some time. I needed to reset SwipeRows to closed immediately and thought others may want the same.