### PR TITLE
Close on row begin swipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ type: `bool`
 defaultValue: `true`
 
 
-### `closeOnScroll`
+### `closeOnRowBeginSwipe`
 
 Should open rows be closed when a row begins to swipe open
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,14 @@ type: `bool`
 defaultValue: `true`
 
 
+### `closeOnScroll`
+
+Should open rows be closed when a row begins to swipe open
+
+type: `bool`
+defaultValue: `false`
+
+
 ### `leftOpenValue`
 
 TranslateX value for opening the row to the left (positive number)

--- a/components/SwipeListView.js
+++ b/components/SwipeListView.js
@@ -23,6 +23,10 @@ class SwipeListView extends Component {
 		this.openCellId = null;
 	}
 
+	horizontalSwipeGestureBegan() {
+		this.safeCloseOpenRow();
+	}
+
 	setScrollEnabled(enable) {
 		this._listView.setNativeProps({scrollEnabled: enable});
 	}
@@ -31,6 +35,12 @@ class SwipeListView extends Component {
 		// if the openCellId is stale due to deleting a row this could be undefined
 		if (this._rows[this.openCellId]) {
 			this._rows[this.openCellId].closeRow();
+		}
+	}
+
+	rowSwipeGestureBegan(id) {
+		if (this.props.closeOnRowBeginSwipe && this.openCellId && this.openCellId !== id) {
+			this.safeCloseOpenRow();
 		}
 	}
 
@@ -80,7 +90,8 @@ class SwipeListView extends Component {
 					onRowClose: _ => this.props.onRowClose && this.props.onRowClose(secId, rowId, this._rows),
 					onRowDidClose: _ => this.props.onRowDidClose && this.props.onRowDidClose(secId, rowId, this._rows),
 					onRowPress: _ => this.onRowPress(`${secId}${rowId}`),
-					setScrollEnabled: enable => this.setScrollEnabled(enable)
+					setScrollEnabled: enable => this.setScrollEnabled(enable),
+					swipeGestureBegan: _ => this.rowSwipeGestureBegan(`${secId}${rowId}`)
 				}
 			);
 		} else {
@@ -88,6 +99,7 @@ class SwipeListView extends Component {
 			return (
 				<SwipeRow
 					ref={row => this._rows[`${secId}${rowId}`] = row}
+					swipeGestureBegan={ _ => this.rowSwipeGestureBegan(`${secId}${rowId}`) }
 					onRowOpen={ _ => this.onRowOpen(secId, rowId, this._rows) }
 					onRowDidOpen={ _ => this.props.onRowDidOpen && this.props.onRowDidOpen(secId, rowId, this._rows)}
 					onRowClose={ _ => this.props.onRowClose && this.props.onRowClose(secId, rowId, this._rows) }
@@ -164,6 +176,10 @@ SwipeListView.propTypes = {
 	 */
 	closeOnRowPress: PropTypes.bool,
 	/**
+	 * Should open rows be closed when a row begins to swipe open
+	 */
+	closeOnRowBeginSwipe: PropTypes.bool,
+	/**
 	 * Disable ability to swipe rows left
 	 */
 	disableLeftSwipe: PropTypes.bool,
@@ -238,6 +254,7 @@ SwipeListView.propTypes = {
 SwipeListView.defaultProps = {
 	leftOpenValue: 0,
 	rightOpenValue: 0,
+	closeOnRowBeginSwipe: false,
 	closeOnScroll: true,
 	closeOnRowPress: true,
 	disableLeftSwipe: false,

--- a/components/SwipeListView.js
+++ b/components/SwipeListView.js
@@ -23,10 +23,6 @@ class SwipeListView extends Component {
 		this.openCellId = null;
 	}
 
-	horizontalSwipeGestureBegan() {
-		this.safeCloseOpenRow();
-	}
-
 	setScrollEnabled(enable) {
 		this._listView.setNativeProps({scrollEnabled: enable});
 	}

--- a/components/SwipeRow.js
+++ b/components/SwipeRow.js
@@ -117,7 +117,10 @@ class SwipeRow extends Component {
 				// set tranlateX value when user started swiping
 				this.swipeInitialX = this.state.translateX._value
 			}
-			this.horizontalSwipeGestureBegan = true;
+			if (!this.horizontalSwipeGestureBegan) {
+				this.horizontalSwipeGestureBegan = true;
+				this.props.swipeGestureBegan && this.props.swipeGestureBegan();
+			}
 
 			let newDX = this.swipeInitialX + dx;
 			if (this.props.disableLeftSwipe  && newDX < 0) { newDX = 0; }
@@ -297,14 +300,18 @@ SwipeRow.propTypes = {
 	 */
 	setScrollEnabled: PropTypes.func,
 	/**
+	 * Called when it has been detected that a row should be swiped open.
+	 */
+	swipeGestureBegan: PropTypes.func,
+	/**
 	 * Called when a swipe row is animating open. Used by the SwipeListView
 	 * to keep references to open rows.
 	 */
 	onRowOpen: PropTypes.func,
-  /**
+	/**
 	 * Called when a swipe row has animated open.
 	 */
-  onRowDidOpen: PropTypes.func,
+	onRowDidOpen: PropTypes.func,
 	/**
 	 * TranslateX value for opening the row to the left (positive number)
 	 */
@@ -349,10 +356,10 @@ SwipeRow.propTypes = {
 	 * Called when a swipe row is animating closed
 	 */
 	onRowClose: PropTypes.func,
-  /**
-   * Called when a swipe row has animated closed
-   */
-  onRowDidClose: PropTypes.func,
+	/**
+	 * Called when a swipe row has animated closed
+	 */
+	onRowDidClose: PropTypes.func,
 	/**
 	 * Styles for the parent wrapper View of the SwipeRow
 	 */
@@ -369,7 +376,7 @@ SwipeRow.propTypes = {
 	 * TranslateX value for the slide out preview animation
 	 * Default: 0.5 * props.rightOpenValue
 	 */
-	previewOpenValue: PropTypes.number
+	previewOpenValue: PropTypes.number,
 };
 
 SwipeRow.defaultProps = {


### PR DESCRIPTION
Adds a `closeOnRowBeginSwipe` prop to close open rows when a row has begun opening.

fixes #98 