### PR TITLE
Add velocity swipeToOpenVelocityContribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,14 @@ type: `number`
 defaultValue: `50`
 
 
+### `swipeToOpenVelocityContribution`
+
+Describes how much the ending velocity of the gesture affects whether the swipe will result in the item being closed or open. A velocity factor of 0 (the default) means that the velocity will have no bearing on whether the swipe settles on a closed or open position and it'll just take into consideration the swipeToOpenPercent. Ideal values for this prop tend to be between 5 and 15.
+
+type: `number`
+defaultValue: `0`
+
+
 ### `disableLeftSwipe`
 
 Disable ability to swipe the row left

--- a/components/SwipeListView.js
+++ b/components/SwipeListView.js
@@ -118,6 +118,7 @@ class SwipeListView extends Component {
 					friction={this.props.friction}
 					directionalDistanceChangeThreshold={this.props.directionalDistanceChangeThreshold}
 					swipeToOpenPercent={this.props.swipeToOpenPercent}
+					velocityFactor={this.props.velocityFactor}
 				>
 					{this.props.renderHiddenRow(rowData, secId, rowId, this._rows)}
 					{this.props.renderRow(rowData, secId, rowId, this._rows)}
@@ -256,6 +257,12 @@ SwipeListView.propTypes = {
 	 * past to trigger the row opening.
 	 */
 	swipeToOpenPercent: PropTypes.number,
+	/**
+	 * Describes how much the ending velocity of the gesture affects whether the swipe will result in the item being closed or open.
+	 * A velocity factor of 0 means that the velocity will have no bearing on whether the swipe settles on a closed or open position
+	 * and it'll just take into consideration the swipeToOpenPercent.
+	 */
+	velocityFactor: PropTypes.number,
 }
 
 SwipeListView.defaultProps = {
@@ -269,7 +276,8 @@ SwipeListView.defaultProps = {
 	recalculateHiddenLayout: false,
 	previewFirstRow: false,
 	directionalDistanceChangeThreshold: 2,
-	swipeToOpenPercent: 50
+	swipeToOpenPercent: 50,
+	velocityFactor: 0
 }
 
 export default SwipeListView;

--- a/components/SwipeListView.js
+++ b/components/SwipeListView.js
@@ -118,7 +118,7 @@ class SwipeListView extends Component {
 					friction={this.props.friction}
 					directionalDistanceChangeThreshold={this.props.directionalDistanceChangeThreshold}
 					swipeToOpenPercent={this.props.swipeToOpenPercent}
-					velocityFactor={this.props.velocityFactor}
+					swipeToOpenVelocityContribution={this.props.swipeToOpenVelocityContribution}
 				>
 					{this.props.renderHiddenRow(rowData, secId, rowId, this._rows)}
 					{this.props.renderRow(rowData, secId, rowId, this._rows)}
@@ -262,7 +262,7 @@ SwipeListView.propTypes = {
 	 * A velocity factor of 0 means that the velocity will have no bearing on whether the swipe settles on a closed or open position
 	 * and it'll just take into consideration the swipeToOpenPercent.
 	 */
-	velocityFactor: PropTypes.number,
+	swipeToOpenVelocityContribution: PropTypes.number,
 }
 
 SwipeListView.defaultProps = {
@@ -277,7 +277,7 @@ SwipeListView.defaultProps = {
 	previewFirstRow: false,
 	directionalDistanceChangeThreshold: 2,
 	swipeToOpenPercent: 50,
-	velocityFactor: 0
+	swipeToOpenVelocityContribution: 0
 }
 
 export default SwipeListView;

--- a/components/SwipeRow.js
+++ b/components/SwipeRow.js
@@ -15,6 +15,8 @@ import {
 
 const PREVIEW_OPEN_DELAY = 700;
 const PREVIEW_CLOSE_DELAY = 300;
+const MAX_VELOCITY_CONTRIBUTION = 5;
+const SCROLL_LOCK_MILLISECONDS = 300;
 
 /**
  * Row that is generally used in a SwipeListView.
@@ -41,7 +43,6 @@ class SwipeRow extends Component {
 			hiddenWidth: 0
 		};
 		this._translateX = new Animated.Value(0);
-		this.ensureScrollEnabled = this.ensureScrollEnabled.bind(this)
 	}
 
 	componentWillMount() {
@@ -140,7 +141,7 @@ class SwipeRow extends Component {
 		}
 	}
 
-	ensureScrollEnabled() {
+	ensureScrollEnabled = () => {
 		if (!this.parentScrollEnabled) {
 			this.parentScrollEnabled = true;
 			this.props.setScrollEnabled && this.props.setScrollEnabled(true);
@@ -152,11 +153,11 @@ class SwipeRow extends Component {
 		// decide how much the velocity will affect the final position that the list item settles in.
 		const swipeToOpenVelocityContribution = this.props.swipeToOpenVelocityContribution;
 		const possibleExtraPixels = this.props.rightOpenValue * (swipeToOpenVelocityContribution);
-		const clampedVelocity = gestureState.vx > 5 ? 5 : gestureState.vx
-		const projectedExtraPixels = possibleExtraPixels * (clampedVelocity / 5);
+		const clampedVelocity = Math.min(gestureState.vx, MAX_VELOCITY_CONTRIBUTION);
+		const projectedExtraPixels = possibleExtraPixels * (clampedVelocity / MAX_VELOCITY_CONTRIBUTION);
 
 		// re-enable scrolling on listView parent
-		this._ensureScrollEnabledTimer = setTimeout(this.ensureScrollEnabled, 300);
+		this._ensureScrollEnabledTimer = setTimeout(this.ensureScrollEnabled, SCROLL_LOCK_MILLISECONDS);
 
 		// finish up the animation
 		let toValue = 0;

--- a/components/SwipeRow.js
+++ b/components/SwipeRow.js
@@ -148,10 +148,10 @@ class SwipeRow extends Component {
 	}
 
 	handlePanResponderEnd(e, gestureState) {
-		
+
 		// decide how much the velocity will affect the final position that the list item settles in.
-		const velocityFactor = this.props.velocityFactor;
-		const possibleExtraPixels = this.props.rightOpenValue * (velocityFactor);
+		const swipeToOpenVelocityContribution = this.props.swipeToOpenVelocityContribution;
+		const possibleExtraPixels = this.props.rightOpenValue * (swipeToOpenVelocityContribution);
 		const projectedExtraPixels = possibleExtraPixels * (gestureState.vx / 5);
 
 		// re-enable scrolling on listView parent
@@ -401,11 +401,11 @@ SwipeRow.propTypes = {
 	 */
 	swipeToOpenPercent: PropTypes.number,
 	/**
-	 * Describes how much the ending velocity of the gesture affects whether the swipe will result in the item being closed or open.
+	 * Describes how much the ending velocity of the gesture contributes to whether the swipe will result in the item being closed or open.
 	 * A velocity factor of 0 means that the velocity will have no bearing on whether the swipe settles on a closed or open position
 	 * and it'll just take into consideration the swipeToOpenPercent.
 	 */
-	velocityFactor: PropTypes.number,
+	swipeToOpenVelocityContribution: PropTypes.number,
 };
 
 SwipeRow.defaultProps = {
@@ -419,7 +419,7 @@ SwipeRow.defaultProps = {
 	previewDuration: 300,
 	directionalDistanceChangeThreshold: 2,
 	swipeToOpenPercent: 50,
-	velocityFactor: 0
+	swipeToOpenVelocityContribution: 0
 };
 
 export default SwipeRow;

--- a/components/SwipeRow.js
+++ b/components/SwipeRow.js
@@ -152,7 +152,8 @@ class SwipeRow extends Component {
 		// decide how much the velocity will affect the final position that the list item settles in.
 		const swipeToOpenVelocityContribution = this.props.swipeToOpenVelocityContribution;
 		const possibleExtraPixels = this.props.rightOpenValue * (swipeToOpenVelocityContribution);
-		const projectedExtraPixels = possibleExtraPixels * (gestureState.vx / 5);
+		const clampedVelocity = gestureState.vx > 5 ? 5 : gestureState.vx
+		const projectedExtraPixels = possibleExtraPixels * (clampedVelocity / 5);
 
 		// re-enable scrolling on listView parent
 		this._ensureScrollEnabledTimer = setTimeout(this.ensureScrollEnabled, 300);

--- a/components/SwipeRow.js
+++ b/components/SwipeRow.js
@@ -148,11 +148,10 @@ class SwipeRow extends Component {
 	}
 
 	handlePanResponderEnd(e, gestureState) {
-		// a velocity factor of 0 means that the velocity will have no baring on whether the swipe settles on a closed or open position.
-		// a velocity factor of n means that a horizontal swipe velocity of 5 or more will project a further n*rightOpenValue more to the _translateX when camparing.
+		
+		// decide how much the velocity will affect the final position that the list item settles in.
 		const velocityFactor = this.props.velocityFactor;
-		const possibleExtraPixels = this.props.rightOpenValue * (this.props.velocityFactor);
-		const clampedVelocity = gestureState.vx > 5 ? 5 : gestureState.vx;
+		const possibleExtraPixels = this.props.rightOpenValue * (velocityFactor);
 		const projectedExtraPixels = possibleExtraPixels * (gestureState.vx / 5);
 
 		// re-enable scrolling on listView parent
@@ -401,6 +400,12 @@ SwipeRow.propTypes = {
 	 * past to trigger the row opening.
 	 */
 	swipeToOpenPercent: PropTypes.number,
+	/**
+	 * Describes how much the ending velocity of the gesture affects whether the swipe will result in the item being closed or open.
+	 * A velocity factor of 0 means that the velocity will have no bearing on whether the swipe settles on a closed or open position
+	 * and it'll just take into consideration the swipeToOpenPercent.
+	 */
+	velocityFactor: PropTypes.number,
 };
 
 SwipeRow.defaultProps = {
@@ -413,7 +418,8 @@ SwipeRow.defaultProps = {
 	preview: false,
 	previewDuration: 300,
 	directionalDistanceChangeThreshold: 2,
-	swipeToOpenPercent: 50
+	swipeToOpenPercent: 50,
+	velocityFactor: 0
 };
 
 export default SwipeRow;

--- a/components/SwipeRow.js
+++ b/components/SwipeRow.js
@@ -55,7 +55,7 @@ class SwipeRow extends Component {
 	}
 
 	componentWillUnmount() {
-		clearTimer(this._ensureScrollEnabledTimer)
+		clearTimeout(this._ensureScrollEnabledTimer)
 	}
 
 	getPreviewAnimation(toValue, delay) {


### PR DESCRIPTION
I noticed that people who try to swipe either pull it across, keeping their finger on the list item, or they try to flick the item across. The swipeToOpenPercent works well for the former but not so well for the latter. When someone flicks the item closed or open, their finger will normally only briefly touch the screen and will travel sufficient distance to switch the state of the list item. Adding velocity into the equation means we can accomodate the flick action that people use as it tends to result in a higher velocity even though it doesn't travel as far.

Another change I did was to either wait until the animation has finished after ending the gesture, or waiting for 300ms before switching the scroll back on. Whichever comes first. I found that turning it on immediately meant that the Y part of the gesture that it ended on could make the list respond vertically to what was intended to be a horizontal swipe. Having that brief period where the scroll remains disabled seems to solve that.

I found a swipeToOpenVelocityContribution of around 5-15 produced desirable results.