### PR TITLE
Introducing swipeToClosePercent

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,14 @@ One case is a SwipeListView with rows of different heights and an options to del
 type: `bool`
 defaultValue: `false`
 
+
+### `swipeGestureBegan`
+
+Called when a swipe row is animating swipe
+
+type: `func`
+
+
 ### `onRowClose`
 
 Called when a swipe row is animating closed

--- a/components/SwipeListView.js
+++ b/components/SwipeListView.js
@@ -40,9 +40,9 @@ class SwipeListView extends Component {
 			this.safeCloseOpenRow();
 		}
 
-    if (this.props.swipeGestureBegan) {
-      this.props.swipeGestureBegan(id);
-    }
+		if (this.props.swipeGestureBegan) {
+			this.props.swipeGestureBegan(id);
+		}
 
 	}
 
@@ -125,6 +125,7 @@ class SwipeListView extends Component {
 					directionalDistanceChangeThreshold={this.props.directionalDistanceChangeThreshold}
 					swipeToOpenPercent={this.props.swipeToOpenPercent}
 					swipeToOpenVelocityContribution={this.props.swipeToOpenVelocityContribution}
+					swipeToClosePercent={this.props.swipeToClosePercent}
 				>
 					{this.props.renderHiddenRow(rowData, secId, rowId, this._rows)}
 					{this.props.renderRow(rowData, secId, rowId, this._rows)}
@@ -269,6 +270,11 @@ SwipeListView.propTypes = {
 	 * and it'll just take into consideration the swipeToOpenPercent.
 	 */
 	swipeToOpenVelocityContribution: PropTypes.number,
+	/**
+	 * What % of the left/right openValue does the user need to swipe
+	 * past to trigger the row closing.
+	 */
+	swipeToClosePercent: PropTypes.number
 }
 
 SwipeListView.defaultProps = {
@@ -283,7 +289,8 @@ SwipeListView.defaultProps = {
 	previewFirstRow: false,
 	directionalDistanceChangeThreshold: 2,
 	swipeToOpenPercent: 50,
-	swipeToOpenVelocityContribution: 0
+	swipeToOpenVelocityContribution: 0,
+	swipeToClosePercent: 50
 }
 
 export default SwipeListView;

--- a/components/SwipeListView.js
+++ b/components/SwipeListView.js
@@ -43,7 +43,6 @@ class SwipeListView extends Component {
 		if (this.props.swipeGestureBegan) {
 			this.props.swipeGestureBegan(id);
 		}
-
 	}
 
 	onRowOpen(secId, rowId, rowMap) {
@@ -203,6 +202,10 @@ SwipeListView.propTypes = {
 	 * One case is a SwipeListView with rows of different heights and an options to delete rows.
 	 */
 	recalculateHiddenLayout: PropTypes.bool,
+	/**
+	 * Called when a swipe row is animating swipe
+	 */
+	swipeGestureBegan: PropTypes.func,
 	/**
 	 * Called when a swipe row is animating open
 	 */

--- a/components/SwipeListView.js
+++ b/components/SwipeListView.js
@@ -39,6 +39,11 @@ class SwipeListView extends Component {
 		if (this.props.closeOnRowBeginSwipe && this.openCellId && this.openCellId !== id) {
 			this.safeCloseOpenRow();
 		}
+
+    if (this.props.swipeGestureBegan) {
+      this.props.swipeGestureBegan(id);
+    }
+
 	}
 
 	onRowOpen(secId, rowId, rowMap) {

--- a/components/SwipeRow.js
+++ b/components/SwipeRow.js
@@ -424,7 +424,7 @@ SwipeRow.propTypes = {
 	 * and it'll just take into consideration the swipeToOpenPercent.
 	 */
 	swipeToOpenVelocityContribution: PropTypes.number,
-  /**
+	/**
 	 * What % of the left/right openValue does the user need to swipe
 	 * past to trigger the row closing.
 	 */

--- a/components/SwipeRow.js
+++ b/components/SwipeRow.js
@@ -163,16 +163,28 @@ class SwipeRow extends Component {
 		// finish up the animation
 		let toValue = 0;
 		if (this._translateX._value >= 0) {
-			// trying to open right
-			if ((this._translateX._value - projectedExtraPixels) > this.props.leftOpenValue * (this.props.swipeToOpenPercent/100)) {
-				// we're more than halfway
-				toValue = this.props.leftOpenValue;
+			// trying to swipe right
+			if (this.swipeInitialX < this._translateX._value) {
+				if ((this._translateX._value - projectedExtraPixels) > this.props.leftOpenValue * (this.props.swipeToOpenPercent/100)) {
+					// we're more than halfway
+					toValue = this.props.leftOpenValue;
+				}
+			} else {
+				if ((this._translateX._value - projectedExtraPixels) > this.props.leftOpenValue * (1 - (this.props.swipeToClosePercent/100))) {
+					toValue = this.props.leftOpenValue;
+				}
 			}
 		} else {
-			// trying to open left
-			if ((this._translateX._value - projectedExtraPixels) < this.props.rightOpenValue * (this.props.swipeToOpenPercent/100)) {
-				// we're more than halfway
-				toValue = this.props.rightOpenValue
+			// trying to swipe left
+			if (this.swipeInitialX > this._translateX._value) {
+				if ((this._translateX._value - projectedExtraPixels) < this.props.rightOpenValue * (this.props.swipeToOpenPercent/100)) {
+					// we're more than halfway
+					toValue = this.props.rightOpenValue;
+				}
+			} else {
+				if ((this._translateX._value - projectedExtraPixels) < this.props.rightOpenValue * (1 - (this.props.swipeToClosePercent/100))) {
+					toValue = this.props.rightOpenValue;
+				}
 			}
 		}
 
@@ -412,6 +424,11 @@ SwipeRow.propTypes = {
 	 * and it'll just take into consideration the swipeToOpenPercent.
 	 */
 	swipeToOpenVelocityContribution: PropTypes.number,
+  /**
+	 * What % of the left/right openValue does the user need to swipe
+	 * past to trigger the row closing.
+	 */
+	swipeToClosePercent: PropTypes.number
 };
 
 SwipeRow.defaultProps = {
@@ -425,7 +442,8 @@ SwipeRow.defaultProps = {
 	previewDuration: 300,
 	directionalDistanceChangeThreshold: 2,
 	swipeToOpenPercent: 50,
-	swipeToOpenVelocityContribution: 0
+	swipeToOpenVelocityContribution: 0,
+	swipeToClosePercent: 50
 };
 
 export default SwipeRow;


### PR DESCRIPTION
Also, expose swipeGestuerBegan callback.

openCellId wasn't being reset when a row is closed.

Shipping down rowData for onRowOpen, onRowDidOpen, onRowClose, and onRowDidClose to increase flexibility.