### PR TITLE
Adding toValue as additional param to onRowOpen

### DIFF
--- a/components/SwipeListView.js
+++ b/components/SwipeListView.js
@@ -82,7 +82,7 @@ class SwipeListView extends Component {
 					...Component.props,
 					ref: row => this._rows[`${secId}${rowId}`] = row,
 					onRowOpen: toValue => this.onRowOpen(secId, rowId, this._rows, toValue),
-					onRowDidOpen: _ => this.props.onRowDidOpen && this.props.onRowDidOpen(secId, rowId, this._rows),
+					onRowDidOpen: releaseValue => this.props.onRowDidOpen && this.props.onRowDidOpen(secId, rowId, this._rows, releaseValue),
 					onRowClose: _ => this.props.onRowClose && this.props.onRowClose(secId, rowId, this._rows),
 					onRowDidClose: releaseValue => this.props.onRowDidClose && this.props.onRowDidClose(secId, rowId, this._rows, releaseValue),
 					onRowPress: _ => this.onRowPress(`${secId}${rowId}`),

--- a/components/SwipeListView.js
+++ b/components/SwipeListView.js
@@ -40,13 +40,13 @@ class SwipeListView extends Component {
 		}
 	}
 
-	onRowOpen(secId, rowId, rowMap) {
+	onRowOpen(secId, rowId, rowMap, toValue) {
 		const cellIdentifier = `${secId}${rowId}`;
 		if (this.openCellId && this.openCellId !== cellIdentifier) {
 			this.safeCloseOpenRow();
 		}
 		this.openCellId = cellIdentifier;
-		this.props.onRowOpen && this.props.onRowOpen(secId, rowId, rowMap);
+		this.props.onRowOpen && this.props.onRowOpen(secId, rowId, rowMap, toValue);
 	}
 
 	onRowPress(id) {
@@ -81,7 +81,7 @@ class SwipeListView extends Component {
 				{
 					...Component.props,
 					ref: row => this._rows[`${secId}${rowId}`] = row,
-					onRowOpen: _ => this.onRowOpen(secId, rowId, this._rows),
+					onRowOpen: toValue => this.onRowOpen(secId, rowId, this._rows, toValue),
 					onRowDidOpen: _ => this.props.onRowDidOpen && this.props.onRowDidOpen(secId, rowId, this._rows),
 					onRowClose: _ => this.props.onRowClose && this.props.onRowClose(secId, rowId, this._rows),
 					onRowDidClose: _ => this.props.onRowDidClose && this.props.onRowDidClose(secId, rowId, this._rows),

--- a/components/SwipeListView.js
+++ b/components/SwipeListView.js
@@ -84,7 +84,7 @@ class SwipeListView extends Component {
 					onRowOpen: toValue => this.onRowOpen(secId, rowId, this._rows, toValue),
 					onRowDidOpen: _ => this.props.onRowDidOpen && this.props.onRowDidOpen(secId, rowId, this._rows),
 					onRowClose: _ => this.props.onRowClose && this.props.onRowClose(secId, rowId, this._rows),
-					onRowDidClose: _ => this.props.onRowDidClose && this.props.onRowDidClose(secId, rowId, this._rows),
+					onRowDidClose: releaseValue => this.props.onRowDidClose && this.props.onRowDidClose(secId, rowId, this._rows, releaseValue),
 					onRowPress: _ => this.onRowPress(`${secId}${rowId}`),
 					setScrollEnabled: enable => this.setScrollEnabled(enable),
 					swipeGestureBegan: _ => this.rowSwipeGestureBegan(`${secId}${rowId}`)

--- a/components/SwipeRow.js
+++ b/components/SwipeRow.js
@@ -141,6 +141,8 @@ class SwipeRow extends Component {
 			this.props.setScrollEnabled && this.props.setScrollEnabled(true);
 		}
 
+		this._releaseValue = this._translateX._value;
+
 		// finish up the animation
 		let toValue = 0;
 		if (this._translateX._value >= 0) {
@@ -177,7 +179,7 @@ class SwipeRow extends Component {
 			}
 		).start( _ => {
 			if (toValue === 0) {
-				this.props.onRowDidClose && this.props.onRowDidClose();
+				this.props.onRowDidClose && this.props.onRowDidClose(this._releaseValue);
 			} else {
 				this.props.onRowDidOpen && this.props.onRowDidOpen();
 			}


### PR DESCRIPTION
While the documentation for onRowOpen callback mentions atValue param the actual implementation provide a different signature (sectionId, rowId, rowMap).
In order to keep backward compatibility and still provide the missing toValue I suggest to append a fourth param so the new signature becomes (sectionId, rowId, rowMap, toValue).
This is a minor change which allows now to detect which direction the swipe had occurred when using SwipeRow inside SwipeListView.

Please see issue https://github.com/jemise111/react-native-swipe-list-view/issues/156 for explanation of problem.
