### PR TITLE
safeCloseOpenRow() to call closeRow() on SwipeRow only

### DIFF
--- a/components/SwipeListView.js
+++ b/components/SwipeListView.js
@@ -30,8 +30,8 @@ class SwipeListView extends Component {
 	}
 
 	safeCloseOpenRow() {
-		// if the openCellKey is stale due to deleting a row this could be undefined
-		if (this._rows[this.openCellKey]) {
+		// only call closeRow() when the openCellKey points to a SwipeRow
+		if (typeof this._rows[this.openCellKey] === 'function') {
 			this._rows[this.openCellKey].closeRow();
 		}
 	}
@@ -195,7 +195,7 @@ SwipeListView.propTypes = {
 	 * To render a custom ListView component, if you don't want to use ReactNative one.
 	 * Note: This will call `renderRow`, not `renderItem`
 	 */
-	renderListView: PropTypes.func, 
+	renderListView: PropTypes.func,
 	/**
 	 * How to render a row in a FlatList. Should return a valid React Element.
 	 */

--- a/components/SwipeListView.js
+++ b/components/SwipeListView.js
@@ -30,8 +30,8 @@ class SwipeListView extends Component {
 	}
 
 	safeCloseOpenRow() {
-		// only call closeRow() when the openCellKey points to a SwipeRow
-		if (typeof this._rows[this.openCellKey] === 'function') {
+		const rowRef = this._rows[this.openCellKey];
+		if (rowRef && rowRef.closeRow) {
 			this._rows[this.openCellKey].closeRow();
 		}
 	}


### PR DESCRIPTION
Currently, `<swipeListView>` does not support `renderRow()` returning components apart from `<SwipeRow>`. In my project, `renderRow` returns either a `<SwipeRow>` or a `<View>` (as a section footer). The problem arises when a `<SwipeRow>` is deleted and then `this._rows[this.openCellKey]` points towards a `<View>` in `safeCloseOpenRow()`. This throws a "closeRow() is not a function" error.

Instead of currently checking if `this._rows[this.openCellKey]` is not `null`, I changed it to check if `closeRow()` function exists in `this._rows[this.openCellKey]` (which indicates that `this._rows[this.openCellKey]` is a `<SwipeRow>` instead of any other component). `closeRow()` can then be safely called.