### PR TITLE
Fix for issue 109

### DIFF
--- a/components/SwipeListView.js
+++ b/components/SwipeListView.js
@@ -7,6 +7,7 @@ import PropTypes from 'prop-types';
 import {
 	FlatList,
 	ListView,
+	Platform,
 	Text,
 	ViewPropTypes,
 	View,
@@ -23,6 +24,17 @@ class SwipeListView extends Component {
 		super(props);
 		this._rows = {};
 		this.openCellKey = null;
+		this.listViewProps = {};
+		if (Platform.OS === 'ios') {
+			// Keep track of scroll offset and layout changes on iOS to be able to handle
+			// https://github.com/jemise111/react-native-swipe-list-view/issues/109
+			this.yScrollOffset = 0;
+			this.layoutHeight = 0;
+			this.listViewProps = {
+				onLayout: e => this.onLayout(e),
+				onContentSizeChange: (w, h) => this.onContentSizeChange(w, h)
+			}
+		}
 	}
 
 	setScrollEnabled(enable) {
@@ -72,6 +84,9 @@ class SwipeListView extends Component {
 	}
 
 	onScroll(e) {
+		if (Platform.OS === 'ios') {
+			this.yScrollOffset = e.nativeEvent.contentOffset.y;
+		}
 		if (this.openCellKey) {
 			if (this.props.closeOnScroll) {
 				this.safeCloseOpenRow();
@@ -79,6 +94,23 @@ class SwipeListView extends Component {
 			}
 		}
 		this.props.onScroll && this.props.onScroll(e);
+	}
+
+	onLayout(e) {
+		this.layoutHeight = e.nativeEvent.layout.height
+		this.props.onLayout && this.props.onLayout(e);
+	}
+
+	// When deleting rows on iOS, the list may end up being over-scrolled,
+	// which will prevent swiping any of the remaining rows. This triggers a scrollToEnd
+	// when that happens, which will make sure the list is kept in bounds.
+	// See: https://github.com/jemise111/react-native-swipe-list-view/issues/109
+	onContentSizeChange(w, h) {
+		const height = h - this.layoutHeight;
+		if (this.yScrollOffset >= height && height > 0) {
+			this._listView && this._listView.getScrollResponder().scrollToEnd();
+		}
+		this.props.onContentSizeChange && this.props.onContentSizeChange(w, h);
 	}
 
 	setRefs(ref) {
@@ -180,6 +212,7 @@ class SwipeListView extends Component {
 			return (
 				<FlatList
 					{...props}
+					{...this.listViewProps}
 					ref={ c => this.setRefs(c) }
 					onScroll={ e => this.onScroll(e) }
 					renderItem={(rowData) => this.renderItem(rowData, this._rows)}
@@ -190,6 +223,7 @@ class SwipeListView extends Component {
 		return (
 			<ListView
 				{...props}
+				{...this.listViewProps}
 				ref={ c => this.setRefs(c) }
 				onScroll={ e => this.onScroll(e) }
 				renderRow={(rowData, secId, rowId) => this.renderRow(rowData, secId, rowId, this._rows)}


### PR DESCRIPTION
This PR aims to fix the overscroll issue https://github.com/jemise111/react-native-swipe-list-view/issues/109, which can happen on iOS when rows are deleted.
The fix is based on the solutions proposed by @dotcink and @seclace.