### PR TITLE
add optional should component update support

### DIFF
--- a/components/SwipeListView.js
+++ b/components/SwipeListView.js
@@ -148,6 +148,7 @@ class SwipeListView extends Component {
 					onRowClose={ _ => this.props.onRowClose && this.props.onRowClose(key, this._rows) }
 					onRowDidClose={ _ => this.props.onRowDidClose && this.props.onRowDidClose(key, this._rows) }
 					onRowPress={ _ => this.onRowPress(key) }
+					shouldItemUpdate={ this.props.shouldItemUpdate ? (currentItem, newItem) => this.props.shouldItemUpdate(currentItem, newItem) : null }
 					setScrollEnabled={ (enable) => this.setScrollEnabled(enable) }
 					leftOpenValue={item.leftOpenValue || this.props.leftOpenValue}
 					rightOpenValue={item.rightOpenValue || this.props.rightOpenValue}
@@ -168,6 +169,7 @@ class SwipeListView extends Component {
 					swipeToOpenPercent={this.props.swipeToOpenPercent}
 					swipeToOpenVelocityContribution={this.props.swipeToOpenVelocityContribution}
 					swipeToClosePercent={this.props.swipeToClosePercent}
+					item={item} // used for should item update comparisons
 				>
 					{HiddenComponent}
 					{VisibleComponent}
@@ -406,7 +408,11 @@ SwipeListView.propTypes = {
 	 * What % of the left/right openValue does the user need to swipe
 	 * past to trigger the row closing.
 	 */
-	swipeToClosePercent: PropTypes.number
+	swipeToClosePercent: PropTypes.number,
+	/**
+	 * callback to determine whether component should update (currentItem, newItem)
+	 */
+	shouldItemUpdate: PropTypes.func,
 }
 
 SwipeListView.defaultProps = {

--- a/components/SwipeRow.js
+++ b/components/SwipeRow.js
@@ -60,6 +60,16 @@ class SwipeRow extends Component {
 		clearTimeout(this._ensureScrollEnabledTimer)
 	}
 
+	shouldComponentUpdate(nextProps, nextState) {
+		if (this.state.hiddenHeight !== nextState.hiddenHeight ||
+			this.state.hiddenWidth !== nextState.hiddenWidth ||
+			(this.props.shouldItemUpdate && this.props.shouldItemUpdate(this.props.item, nextProps.item))) {
+			return true
+		}
+
+		return false;
+	}
+
 	getPreviewAnimation(toValue, delay) {
 		return Animated.timing(
 			this._translateX,
@@ -430,7 +440,11 @@ SwipeRow.propTypes = {
 	 * What % of the left/right openValue does the user need to swipe
 	 * past to trigger the row closing.
 	 */
-	swipeToClosePercent: PropTypes.number
+	swipeToClosePercent: PropTypes.number,
+	/**
+	 * callback to determine whether component should update (currentItem, newItem)
+	 */
+	shouldItemUpdate: PropTypes.func,
 };
 
 SwipeRow.defaultProps = {
@@ -446,7 +460,8 @@ SwipeRow.defaultProps = {
 	directionalDistanceChangeThreshold: 2,
 	swipeToOpenPercent: 50,
 	swipeToOpenVelocityContribution: 0,
-	swipeToClosePercent: 50
+	swipeToClosePercent: 50,
+	item: {}
 };
 
 export default SwipeRow;


### PR DESCRIPTION
_This was a quick change to improve performance - i might not have covered all use cases._

FlatLists with more than the initial render amount can call render multiple times for each item in the list (https://github.com/facebook/react-native/issues/14528)

This change gives the ability to reduce the amount of renders for each swiperow when in SwipeListView (flatlist); so they only render when they need to.

Exposed as "shouldItemUpdate": passes along the current item (previous) blob and the new item from data blob for comparison. return false to skip rendering