### PR TITLE
Remove incorrectly bound argument

### DIFF
--- a/components/SwipeListView.js
+++ b/components/SwipeListView.js
@@ -221,7 +221,7 @@ class SwipeListView extends Component {
 				props,
 				this.setRefs.bind(this),
 				this.onScroll.bind(this),
-				(useFlatList || useSectionList) ? this.renderItem.bind(this) : this.renderRow.bind(this, this._rows),
+				(useFlatList || useSectionList) ? this.renderItem.bind(this) : this.renderRow.bind(this),
 			);
 		}
 


### PR DESCRIPTION
Passing the row map `this._rows` as `rowData` to `renderRow` seems wrong and makes things sad for me when I'm trying to use another list component.

It's been like this since @magrinj added the feature in #165 and I'm not sure why...
This fix makes the third party list component work for me.