### PR TITLE
Avoid ListView deprecation warning

### DIFF
--- a/components/SwipeListView.js
+++ b/components/SwipeListView.js
@@ -115,12 +115,13 @@ class SwipeListView extends Component {
 	// when that happens, which will make sure the list is kept in bounds.
 	// See: https://github.com/jemise111/react-native-swipe-list-view/issues/109
 	onContentSizeChange(w, h) {
+		const { useFlatList, useSectionList } = this.props;
 		const height = h - this.layoutHeight;
 		if (this.yScrollOffset >= height && height > 0) {
-			if (this._listView instanceof ListView){
+			if (!useFlatList && !useSectionList && this._listView instanceof ListView) {
 				this._listView && this._listView.getScrollResponder().scrollToEnd();
 			}
-			if  (this._listView instanceof FlatList){
+			if (this._listView instanceof FlatList) {
 				this._listView && this._listView.scrollToEnd();
 			}
 		}


### PR DESCRIPTION
Accessing ListView throws a deprecation warning. Even though this is harmless, it causes confusion.

With this change, we don't access ListView if we have explicitly opted to use FlatList or SectionList.