### PR TITLE
Add "disableHiddenLayoutCalculation" prop

### DIFF
--- a/components/SwipeListView.js
+++ b/components/SwipeListView.js
@@ -170,6 +170,7 @@ class SwipeListView extends Component {
 					stopLeftSwipe={item.stopLeftSwipe || this.props.stopLeftSwipe}
 					stopRightSwipe={item.stopRightSwipe || this.props.stopRightSwipe}
 					recalculateHiddenLayout={this.props.recalculateHiddenLayout}
+					disableHiddenLayoutCalculation={this.props.disableHiddenLayoutCalculation}
 					style={this.props.swipeRowStyle}
 					preview={shouldPreviewRow}
 					previewDuration={this.props.previewDuration}
@@ -338,6 +339,13 @@ SwipeListView.propTypes = {
 	 */
 	recalculateHiddenLayout: PropTypes.bool,
 	/**
+	 * Disable hidden row onLayout calculations
+	 * 
+	 * Instead, {width: '100%', height: '100%'} will be used.
+	 * Improves performance by avoiding component updates, while still working with orientation changes.
+	 */
+	disableHiddenLayoutCalculation: PropTypes.bool,
+	/**
 	 * Called when a swipe row is animating swipe
 	 */
 	swipeGestureBegan: PropTypes.func,
@@ -445,6 +453,7 @@ SwipeListView.defaultProps = {
 	disableLeftSwipe: false,
 	disableRightSwipe: false,
 	recalculateHiddenLayout: false,
+	disableHiddenLayoutCalculation: false,
 	previewFirstRow: false,
 	directionalDistanceChangeThreshold: 2,
 	swipeToOpenPercent: 50,

--- a/components/SwipeRow.js
+++ b/components/SwipeRow.js
@@ -43,8 +43,8 @@ class SwipeRow extends Component {
 		this._ensureScrollEnabledTimer = null
 		this.state = {
 			dimensionsSet: false,
-			hiddenHeight: 0,
-			hiddenWidth: 0
+			hiddenHeight: this.props.disableHiddenLayoutCalculation ? '100%' : 0,
+			hiddenWidth: this.props.disableHiddenLayoutCalculation ? '100%' : 0
 		};
 		this._translateX = new Animated.Value(0);
 		if (this.props.onSwipeValueChange) {
@@ -100,8 +100,10 @@ class SwipeRow extends Component {
 	onContentLayout(e) {
 		this.setState({
 			dimensionsSet: !this.props.recalculateHiddenLayout,
-			hiddenHeight: e.nativeEvent.layout.height,
-			hiddenWidth: e.nativeEvent.layout.width,
+			...(!this.props.disableHiddenLayoutCalculation ? {
+				hiddenHeight: e.nativeEvent.layout.height,
+				hiddenWidth: e.nativeEvent.layout.width,
+			} : {})
 		});
 
 		if (this.props.preview && !this.ranPreview) {
@@ -418,6 +420,10 @@ SwipeRow.propTypes = {
 	 */
 	recalculateHiddenLayout: PropTypes.bool,
 	/**
+	 * Disable hidden row onLayout calculations
+	 */
+	disableHiddenLayoutCalculation: PropTypes.bool,
+	/**
 	 * Called when a swipe row is animating closed
 	 */
 	onRowClose: PropTypes.func,
@@ -479,6 +485,7 @@ SwipeRow.defaultProps = {
 	disableLeftSwipe: false,
 	disableRightSwipe: false,
 	recalculateHiddenLayout: false,
+	disableHiddenLayoutCalculation: false,
 	preview: false,
 	previewDuration: 300,
 	previewOpenDelay: DEFAULT_PREVIEW_OPEN_DELAY,


### PR DESCRIPTION
Disables hidden row onLayout calculations
Instead, {width: '100%', height: '100%'} will be used.
It improves performance by avoiding component updates, while still working with orientation changes.
Fixes #267 