### PR TITLE
Preserve arguments for onPress

### DIFF
--- a/components/SwipeRow.js
+++ b/components/SwipeRow.js
@@ -262,9 +262,9 @@ class SwipeRow extends Component {
 		const onPress = this.props.children[1].props.onPress;
 
 		if (onPress) {
-			const newOnPress = _ => {
+			const newOnPress = (...args) => {
 				this.onRowPress();
-				onPress();
+				onPress(...args);
 			}
 			return React.cloneElement(
 				this.props.children[1],


### PR DESCRIPTION
`renderVisibleContent()` hijacks `onPress` and invokes the method from a wrapper function. This is fine, except that any arguments passed to the original `onPress` are not preserved when the function is invoked from inside the wrapper.