### PR TITLE
Force-closing to left/right end on hitting threshold.

### DIFF
--- a/components/SwipeRow.js
+++ b/components/SwipeRow.js
@@ -555,11 +555,11 @@ SwipeRow.propTypes = {
 	 */
 	onSwipeValueChange: PropTypes.func,
 	/**
-	 * TranslateX value for force-closing the row to the Left End (positive number)
+	 * TranslateX amount(not value!) threshold that triggers force-closing the row to the Left End (positive number)
 	 */
 	forceCloseToLeftThreshold: PropTypes.number,
 	/**
-	 * TranslateX value for force-closing the row to the Right End (negative number)
+	 * TranslateX amount(not value!) threshold that triggers force-closing the row to the Right End (positive number)
 	 */
 	forceCloseToRightThreshold: PropTypes.number,
 	/**

--- a/components/SwipeRow.js
+++ b/components/SwipeRow.js
@@ -172,7 +172,9 @@ class SwipeRow extends Component {
 
 	handlePanResponderMove(e, gestureState) {
 		/* If the view is force closing, then ignore Moves. Return */
-		if(this.state.isForceClosing) return;
+		if(this.state.isForceClosing) {
+			return;
+		}
 
 		/* Else, do normal job */
 		const { dx, dy } = gestureState;
@@ -319,8 +321,9 @@ class SwipeRow extends Component {
 				this.isOpen = true;
 				this.props.onRowDidOpen && this.props.onRowDidOpen(toValue);
 			}
-			if(onAnimationEnd)
+			if(onAnimationEnd) {
 				onAnimationEnd();
+			}
 		});
 
 		if (toValue === 0) {

--- a/docs/SwipeRow.md
+++ b/docs/SwipeRow.md
@@ -43,3 +43,9 @@ e.g.
 | `swipeGestureBegan` | Called when the row is animating swipe | `func` | `{ } : void`
 | `swipeToOpenVelocityContribution` | Describes how much the ending velocity of the gesture affects whether the swipe will result in the item being closed or open. A velocity factor of 0 (the default) means that the velocity will have no bearing on whether the swipe settles on a closed or open position and it'll just take into consideration the swipeToOpenPercent. Ideal values for this prop tend to be between 5 and 15. | `number` || `0`
 | `shouldItemUpdate` | Callback to determine whether component should update | `func` | `{ currentItem: any, newItem: any }`
+| `forceCloseToLeftThreshold` | TranslateX amount(not value!) threshold that triggers force-closing the row to the Left End (positive number) | `number` |
+| `forceCloseToRightThreshold` | TranslateX amount(not value!) threshold that triggers force-closing the row to the Right End (positive number) | `number` |
+| `onForceCloseToLeft` | Callback invoked when row is force closing to the Left End | `func` |
+| `onForceCloseToRight` | Callback invoked when row is force closing to the Right End | `func` |
+| `onForceCloseToLeftEnd` | Callback invoked when row has finished force closing to the Left End | `func` |
+| `onForceCloseToRightEnd` | Callback invoked when row has finished force closing to the Right End | `func` |


### PR DESCRIPTION
Force-closing feature added to SwipeRow.

The forceClosing can happen when the threshold is hit while swiping from Right-to-Left or Left-To-Right.

Not like `stopRightSwipe` or `stopLeftSwipe`, the `forceCloseToRightThreshold` and `forceCloseToLeftThreshold` are values to CLOSE the row even if the panMovement is not finished.

Both `forceCloseToRightThreshold` and `forceCloseToLeftThreshold` takes positive value.
Those values can be thought as to represent the 'left-over-width' of the row. 

For example, `forceCloseToRightThreshold={100}` can mean when there only 100 px or less of visibleRow is left while swipe-opening from Right to Left, then force close to the right end.

And for each direction, two callbacks can be called. For closing-to-right situation, `onForceCloseToRight' and `onForceCloseToRightEnd' can be called. `onForceCloseToRight` will run when force closing is started, and `onForceCloseToRight` will run when force closing animation is finished.

* props for SwipeRow

```JSX
{
	...
	/**
	 * TranslateX value for force-closing the row to the Left End (positive number)
	 */
	forceCloseToLeftThreshold: PropTypes.number,
	/**
	 * TranslateX value for force-closing the row to the Right End (negative number)
	 */
	forceCloseToRightThreshold: PropTypes.number,
	/**
	 * Callback invoked when row is force closing to the Left End
	 */
	onForceCloseToLeft: PropTypes.func,
	/**
	 * Callback invoked when row is force closing to the Right End
	 */
	onForceCloseToRight: PropTypes.func,
	/**
	 * Callback invoked when row has finished force closing to the Left End
	 */
	onForceCloseToLeftEnd: PropTypes.func,
	/**
	 * Callback invoked when row has finished force closing to the Right End
	 */
	onForceCloseToRightEnd: PropTypes.func
}
```

* Example:
```JSX
import React, { useState } from 'react';
import { useSelector, useDispatch } from "react-redux";
import {
  Animated,
  StyleSheet,
  View,
  TouchableOpacity,
} from 'react-native';
import {
  SafeAreaView, 
} from 'react-navigation';
import {
  Icon,
} from 'react-native-elements';
import { 
  SwipeListView,
  SwipeRow, 
} from 'react-native-swipe-list-view';
import { toPascalCase, $T } from '../Helpers';
import Layout from '../constants/Layout';
import TitleHeader from "../components/TitleHeader";
import Notification from '../components/Notification';
import { TextRegular } from "../components/Text";
import { ButtonRegular } from "../components/Button";

const AllNotificationsScreen = props => {
  const { navigation } = props;

  const language = useSelector(state => state.languageReducer.language);
  const theme = useSelector(state => state.themeReducer.theme);
  const notifications = useSelector(state => state.notificationsReducer.notifications);
  const dispatch = useDispatch();

  const [ showAll, setShowAll ] = useState(false);

  const readWidthAnimations = {};
  const collapseAnimations = {};

  const data = (showAll ? notifications : notifications.filter(n => !n.is_read)).map(n => {
    const notification = { ...n };

    readWidthAnimations[notification.id] = new Animated.Value(100);
    collapseAnimations[notification.id] = new Animated.Value(0);

    return notification;
  });

  const renderItem = ({ item, index }) => {
    return (
      <SwipeRow
        disableRightSwipe={true}
        rightOpenValue={-100}
        forceCloseToRightThreshold={150}
        onSwipeValueChange={(swipeData) => {
          const { key, value } = swipeData;
          readWidthAnimations[item.id].setValue(value < -100 ? ((-(value + 100) + 105 - ((value + 100) / 2)) <= Layout.window.width - 25 ? (-(value + 100) + 105 - ((value + 100) / 2)) : Layout.window.width - 25 ) : 105);
        }}
        onForceCloseToRight={() => {
          dispatch({ type: "FORCE_CLOSING", payload: item.id})
        }}
        onForceCloseToRightEnd={() => {
          dispatch({ type: "FORCE_CLOSING_END", payload: item.id})
        }}
      >
        <View style={styles.rowBack}>
          {
            item.is_read ? (
              <Animated.View style={[ styles.unread, { width: readWidthAnimations[item.id] } ]}>
                <TouchableOpacity 
                  style={{ justifyContent: 'center', alignItems: "center", width: 105 }}
                  onPress={() => dispatch({ type: "TOGGLE_NOTIFICATION", payload: item.id})}
                >
                  <Icon
                    name='md-radio-button-on'
                    type='ionicon'
                    color='white'
                  />
                  <TextRegular numberOfLines={1} style={styles.readText}>{$T(language, "AllNotificationsScreenButtonUnread")}</TextRegular>
                </TouchableOpacity>
              </Animated.View>
            ) : (
              <Animated.View style={[ styles.read, { width: readWidthAnimations[item.id] } ]}>
                <TouchableOpacity 
                  style={{ justifyContent: 'center', alignItems: "center", width: 105 }}
                  onPress={() => dispatch({ type: "TOGGLE_NOTIFICATION", payload: item.id})}
                >
                  <Icon
                    name='md-checkmark-circle-outline'
                    type='ionicon'
                    color='white'
                  />
                  <TextRegular numberOfLines={1} style={styles.readText}>{$T(language, "AllNotificationsScreenButtonRead")}</TextRegular>
                </TouchableOpacity>
              </Animated.View>
            )
          }
        </View>
        <Notification type={toPascalCase(item.action_status)} data={item} isForceClosing={item.isForceClosing} isForceClosingEnd={item.isForceClosingEnd}/>
      </SwipeRow>
    );
  };

  return (
    <SafeAreaView style={[styles.container, { backgroundColor: theme.PRIMARY_BACKGROUND_COLOR }]} forceInset={{ bottom: "never" }}>
      <TitleHeader noDuration title={$T(language, "AllNotificationsScreenTitle")} onPress={() => this.flatList.scrollToOffset({x: 0, y: 0, animated: true}) }/>
      <View style={[styles.body, { backgroundColor: theme.PRIMARY_BACKGROUND_COLOR_LIGHT }]}>
        <View style={styles.buttons}>
          <ButtonRegular
            buttonStyle={styles.button}
            titleStyle={styles.buttonTitle}
            title={showAll ? $T(language, "AllNotificationsScreenButtonShowLess") : $T(language, "AllNotificationsScreenButtonShowAll")}
            onPress={() => {
              if(showAll === true)
                setShowAll(false);
              else
                setShowAll(true);
            }}
          />
          <ButtonRegular
            buttonStyle={styles.button}
            titleStyle={styles.buttonTitle}
            title={$T(language, "AllNotificationsScreenButtonMarkAllAsRead")}
            onPress={() => dispatch({ type: "READ_ALL_NOTIFICATIONS" })}
          />
        </View>
        <SwipeListView
          useFlatList
          contentContainerStyle={styles.flatList}
          listViewRef={ flatList => this.flatList = flatList }
          showsVerticalScrollIndicator={false}
          keyExtractor={notification => notification.id}
          data={data}
          renderItem={renderItem}
          closeOnRowPress={true}
          recalculateHiddenLayout={true}
        />
      </View>
    </SafeAreaView>
  );
};

export default AllNotificationsScreen;

const styles = StyleSheet.create({
  container: {
    flex: 1,
  },
  body: {
    flex: 1,
    backgroundColor: '#eee',
  },
  buttons: {
    flexDirection: 'row',
    justifyContent: "space-between",
    margin: 10,
  },
  button: {
    padding: 0, 
    backgroundColor: "transparent"
  },
  buttonTitle: {
    color: "#777",
    fontSize: 14,
  },
  flatList: {
    paddingLeft: 10,
    paddingRight: 10,
    paddingBottom: Layout.safePaddingBottom,
  },
  rowBack: {
    flex: 1,
    flexDirection: 'row',
    justifyContent: 'flex-end',
    marginBottom: 10,
  },
  read: {
    width: 100,
    backgroundColor: 'rgba(78, 162, 53, 1)',
    alignItems: 'center',
    justifyContent: 'center',
  },
  readText: {
    fontSize: 16,
    color: 'white'
  },
  unread: {
    width: 100,
    backgroundColor: 'rgba(0, 122, 255, 1)',
    alignItems: 'center',
    justifyContent: 'center',
  },
  unreadText: {
    fontSize: 16,
    color: 'white'
  },
});
```

* And it looks like this:

![forceClose](https://user-images.githubusercontent.com/4941095/59787642-e6b74c00-9297-11e9-92fc-ea0d2870cb9c.gif)
