### PR TITLE
Re-add renderItem type definition

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -155,7 +155,7 @@ interface IPropsSwipeListView<T> {
 	/**
 	 * How to render a row in a FlatList. Should return a valid React Element.
 	 */
-	// renderItem(rowData: ListRenderItemInfo<T>, rowMap: RowMap<T>): JSX.Element | null;
+	renderItem(rowData: ListRenderItemInfo<T>, rowMap: RowMap<T>): JSX.Element | null;
 	/**
 	 * How to render a hidden row in a FlatList (renders behind the row). Should return a valid React Element.
 	 * This is required unless renderItem is passing a SwipeRow.


### PR DESCRIPTION
Internally the SwipeListView component passes a `RowMap`(see https://github.com/jemise111/react-native-swipe-list-view/blob/e16ad2fd0fc96f5cd645ea4720890c926cd1f0a0/components/SwipeListView.js#L202) but for some reason this line was commented without any explanation. This is still useful for people that are manually implementing `SwipeRow`, like me.

May sound egoistical but I don't see any negative side effects of having this on.