### PR TITLE
Fix an issue that caused rows to be swiped with a quick swipe when ve…

### DIFF
--- a/components/SwipeRow.js
+++ b/components/SwipeRow.js
@@ -282,6 +282,8 @@ class SwipeRow extends Component {
         let toValue = 0;
         if (this.currentTranslateX >= 0) {
             // trying to swipe right
+            if (this.props.disableRightSwipe) return;
+
             if (this.swipeInitialX < this.currentTranslateX) {
                 if (
                     this.currentTranslateX - projectedExtraPixels >
@@ -302,6 +304,8 @@ class SwipeRow extends Component {
             }
         } else {
             // trying to swipe left
+            if (this.props.disableLeftSwipe) return;
+
             if (this.swipeInitialX > this.currentTranslateX) {
                 if (
                     this.currentTranslateX - projectedExtraPixels <


### PR DESCRIPTION
When `swipeToOpenVelocityContribution` is set to a number above `0`, even if a swipe is disabled in a certain direction, it is possible to swipe open a row by swiping quickly. This pull request fixes this issue.