### PR TITLE
add accessible false to touchableopacity

### DIFF
--- a/components/SwipeRow.js
+++ b/components/SwipeRow.js
@@ -415,7 +415,11 @@ class SwipeRow extends Component {
         }
 
         return (
-            <TouchableOpacity activeOpacity={1} onPress={this.combinedOnPress}>
+            <TouchableOpacity
+                activeOpacity={1}
+                onPress={this.combinedOnPress}
+                accessible={false}
+            >
                 {this.props.children[1]}
             </TouchableOpacity>
         );


### PR DESCRIPTION
There is a TouchableOpacity element that wraps the visible child passed through to SwipeRow.
It blocks accessibility to those inner child components.
To fix this I've added `accessible={false}` to TouchableOpacity.

Before:
![without_accessible_false](https://user-images.githubusercontent.com/32861674/67542573-1e983980-f739-11e9-9b15-3fcdc0143deb.gif)

After:
![with_accessible_false](https://user-images.githubusercontent.com/32861674/67542522-e0027f00-f738-11e9-96f3-8c81fd01dd95.gif)


* [✓] I ran `yarn run fix` on my PR and fixed any formatting issues
