### PR TITLE
ForceClosing bug fixes

### DIFF
--- a/components/SwipeRow.js
+++ b/components/SwipeRow.js
@@ -285,7 +285,9 @@ class SwipeRow extends Component {
     handlePanResponderEnd(e, gestureState) {
         /* PandEnd will reset the force-closing state when it's true. */
         if (this.isForceClosing) {
-            this.isForceClosing = false;
+            setTimeout(() => {
+                this.isForceClosing = false;
+            }, 500); // 500 is the default Animated.spring's duration used in manuallySwipeRow
         }
         // decide how much the velocity will affect the final position that the list item settles in.
         const swipeToOpenVelocityContribution = this.props
@@ -318,7 +320,9 @@ class SwipeRow extends Component {
                         (this.props.swipeToOpenPercent / 100)
                 ) {
                     // we're more than halfway
-                    toValue = this.props.leftOpenValue;
+                    toValue = this.isForceClosing
+                        ? 0
+                        : this.props.leftOpenValue;
                 }
             } else {
                 if (
@@ -326,7 +330,9 @@ class SwipeRow extends Component {
                     this.props.leftOpenValue *
                         (1 - this.props.swipeToClosePercent / 100)
                 ) {
-                    toValue = this.props.leftOpenValue;
+                    toValue = this.isForceClosing
+                        ? 0
+                        : this.props.leftOpenValue;
                 }
             }
         } else {
@@ -340,7 +346,9 @@ class SwipeRow extends Component {
                         (this.props.swipeToOpenPercent / 100)
                 ) {
                     // we're more than halfway
-                    toValue = this.props.rightOpenValue;
+                    toValue = this.isForceClosing
+                        ? 0
+                        : this.props.rightOpenValue;
                 }
             } else {
                 if (
@@ -348,7 +356,9 @@ class SwipeRow extends Component {
                     this.props.rightOpenValue *
                         (1 - this.props.swipeToClosePercent / 100)
                 ) {
-                    toValue = this.props.rightOpenValue;
+                    toValue = this.isForceClosing
+                        ? 0
+                        : this.props.rightOpenValue;
                 }
             }
         }


### PR DESCRIPTION
Thanks for submitting a pull request!

**Please confirm you have linted your code and fixed any issues:**

* [x] I ran `yarn run fix` on my PR and fixed any formatting issues

**Please provide information on what your PR achieves and any issues that it addresses:**

### ForceClosing callback was double fired. Fixed. 
- For example, `onForceCloseToRight` callback was fired twice on force-close

### Force-closing row wasn't manually closing the row all the way down to 0. Fixed.
- For example, when the row was force-closed manually, it stayed open stopped at the `leftOpenValue` or `rightOpenValue` depends on the direction. Now fully closes as usual.
