### PR TITLE
Fixed rows not closing on refresh on android

### DIFF
--- a/components/SwipeListView.js
+++ b/components/SwipeListView.js
@@ -26,6 +26,11 @@ class SwipeListView extends Component {
             };
         }
     }
+    
+    componentWillReceiveProps(nextProps) {
+		if(nextProps.refreshing)
+			this.safeCloseOpenRow();
+	}
 
     setScrollEnabled(enable) {
         if (this.props.scrollEnabled === false) {

--- a/components/SwipeListView.js
+++ b/components/SwipeListView.js
@@ -26,11 +26,10 @@ class SwipeListView extends Component {
             };
         }
     }
-    
-    componentWillReceiveProps(nextProps) {
-		if(nextProps.refreshing)
-			this.safeCloseOpenRow();
-	}
+
+    componentDidUpdate(nextProps) {
+        if (nextProps.refreshing) this.safeCloseOpenRow();
+    }
 
     setScrollEnabled(enable) {
         if (this.props.scrollEnabled === false) {

--- a/components/SwipeListView.js
+++ b/components/SwipeListView.js
@@ -27,8 +27,8 @@ class SwipeListView extends Component {
         }
     }
 
-    componentDidUpdate(nextProps) {
-        if (nextProps.refreshing) this.safeCloseOpenRow();
+    componentDidUpdate() {
+        if (this.props.refreshing) this.safeCloseOpenRow();
     }
 
     setScrollEnabled(enable) {


### PR DESCRIPTION
On android, if you are using "refreshing" and "onRefresh", open rows will stay open after the refresh. (On iOS, when you're at the top and pull to refresh, it does scroll a bit, which will fire safeCloseOpenRow if closeOnScroll=true).
