### PR TITLE
Add type definition for manuallySwipeRow

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -140,6 +140,7 @@ export class SwipeRow<T> extends Component<Partial<IPropsSwipeRow<T>>> {
 	closeRow: () => void;
 	closeRowWithoutAnimation: () => void;
 	render(): JSX.Element;
+	manuallySwipeRow: (toValue: number, onAnimationEnd?: () => void) => void;
 }
 
 type IRenderListViewProps<T> = Omit<Omit<Omit<IPropsSwipeListView<T>, 'useFlatList'>, 'useSectionList'>, 'renderListView'>;


### PR DESCRIPTION
**Please confirm you have linted your code and fixed any issues:**

* [ ] I ran `yarn run fix` on my PR and fixed any formatting issues

**Please provide information on what your PR achieves and any issues that it addresses:**

Following @jemise111 's comment in https://github.com/jemise111/react-native-swipe-list-view/issues/361#issuecomment-552114614

> I'm hesitant to add it to types because it's not really supported functionality (though a PR is always welcome if you'd like to add it)

I feel like it's been recommended a few times in the issues by the author, so that it is de facto "supported", might as well have the type definition?

Tested in a local project by adding

```
declare module 'react-native-swipe-list-view' {
  interface SwipeRow<T> {
    manuallySwipeRow: (toValue: number, onAnimationEnd?: () => void) => void;
  }
}
```
and verifying no typescript error on usage of `manuallySwipeRow`

Thanks for submitting a pull request!
