### PR TITLE
Opt in to animated lists

### DIFF
--- a/components/SwipeListView.js
+++ b/components/SwipeListView.js
@@ -2,7 +2,13 @@
 
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { Animated, Platform, ViewPropTypes } from 'react-native';
+import {
+    Animated,
+    FlatList,
+    Platform,
+    SectionList,
+    ViewPropTypes,
+} from 'react-native';
 
 import SwipeRow from './SwipeRow';
 
@@ -123,7 +129,9 @@ class SwipeListView extends PureComponent {
     onContentSizeChange(w, h) {
         const height = h - this.layoutHeight;
         if (this.yScrollOffset >= height && height > 0) {
-            if (this._listView instanceof Animated.FlatList) {
+            if (this._listView instanceof FlatList) {
+                this._listView && this._listView.scrollToEnd();
+            } else if (this._listView instanceof Animated.FlatList) {
                 this._listView.scrollToEnd && this._listView.scrollToEnd();
             }
         }
@@ -319,8 +327,11 @@ class SwipeListView extends PureComponent {
         }
 
         if (useSectionList) {
+            const ListComponent = this.props.useAnimatedList
+                ? Animated.SectionList
+                : SectionList;
             return (
-                <Animated.SectionList
+                <ListComponent
                     {...props}
                     {...this.listViewProps}
                     ref={this._onRef}
@@ -329,9 +340,11 @@ class SwipeListView extends PureComponent {
                 />
             );
         }
-
+        const ListComponent = this.props.useAnimatedList
+            ? Animated.FlatList
+            : FlatList;
         return (
-            <Animated.FlatList
+            <ListComponent
                 {...props}
                 {...this.listViewProps}
                 ref={this._onRef}
@@ -535,6 +548,10 @@ SwipeListView.propTypes = {
      * useNativeDriver: true for all animations where possible
      */
     useNativeDriver: PropTypes.bool,
+    /**
+     * Use Animated.Flatlist or Animated.Sectionlist
+     */
+    useAnimatedList: PropTypes.bool,
 };
 
 SwipeListView.defaultProps = {
@@ -556,6 +573,7 @@ SwipeListView.defaultProps = {
     useNativeDriver: true,
     previewRepeat: false,
     previewRepeatDelay: 1000,
+    useAnimatedList: false,
 };
 
 export default SwipeListView;

--- a/docs/SwipeListView.md
+++ b/docs/SwipeListView.md
@@ -48,3 +48,4 @@ A List that renders `<SwipeRow />`s
 | `previewRowIndex` [DEPRECATED] | Should the specified rowId do a slide out preview to show that the list is swipeable. ***Note***: This ID will be passed to this function to get the correct row index. https://facebook.github.io/react-native/docs/listviewdatasource.html#getrowidforflatindex | `number`
 | `shouldItemUpdate` | Callback to determine whether component should update | `func` | `{ currentItem: any, newItem: any }`
 | `useNativeDriver` | useNativeDriver: `true` for all animations | `bool` | `true` |
+| `useAnimatedList` | Use Animated.Flatlist or Animated.Sectionlist | `bool` | `false` |


### PR DESCRIPTION
This PR addresses issues that arose following the release of #428 

Namely by changing `FlatList` to `Animated.FlatList` all `ref`s that previously expected to find a `FlatList` are now experiencing inconsistent behavior.

This PR makes the use of `Animated.Flatlist` an opt in instead of the default. (same goes for sectionlist)
