### PR TITLE
Fixed inconsistent prop name for opting in animated list

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -476,7 +476,7 @@ interface IPropsSwipeListView<T> {
 	/**
 	 * Use Animated.Flatlist or Animated.Sectionlist
 	 */
-	useAnimateList: boolean;
+	useAnimatedList: boolean;
 }
 
 type SectionListPropsOverride<T> = Omit<SectionListProps<T>, 'renderItem'>


### PR DESCRIPTION
Fixed inconsistent prop name for opting in animated list

**Please confirm you have linted your code and fixed any issues:**

* [ x] I ran `yarn run fix` on my PR and fixed any formatting issues

**Please provide information on what your PR achieves and any issues that it addresses:**

Prop name useAnimateList in type declaration file is inconsistent with what being used in source code (useAnimatedList)