### PR TITLE
Added this.props.onScroll null check

### DIFF
--- a/components/SwipeListView.js
+++ b/components/SwipeListView.js
@@ -32,7 +32,7 @@ class SwipeListView extends PureComponent {
             };
         }
         this._onScroll = this.onScroll.bind(this);
-        if (typeof this.props.onScroll === 'object') {
+        if (this.props.onScroll && typeof this.props.onScroll === 'object') {
             // Animated.event
             this.props.onScroll.__addListener(this._onScroll);
             this._onScroll = this.props.onScroll;


### PR DESCRIPTION
The check must be done because `typeof null` is also `object`. If it was explicity passed null to onScroll, the app would throw the crash `null is not an object (evaluating 'this.props.onScroll.__addListener'`

Thanks for submitting a pull request!

**Please confirm you have linted your code and fixed any issues:**

* [X] I ran `yarn run fix` on my PR and fixed any formatting issues
