### PR TITLE
Fixed hidden item renderer return type.

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -241,7 +241,7 @@ interface IPropsSwipeListView<T> {
 	 * How to render a hidden row in a FlatList (renders behind the row). Should return a valid React Element.
 	 * This is required unless renderItem is passing a SwipeRow.
 	 */
-	renderHiddenItem(rowData: ListRenderItemInfo<T>, rowMap: RowMap<T>): JSX.Element;
+	renderHiddenItem(rowData: ListRenderItemInfo<T>, rowMap: RowMap<T>): JSX.Element | null;
 	/**
 	 * [DEPRECATED] How to render a row in a ListView. Should return a valid React Element.
 	 */


### PR DESCRIPTION
Fixed type-checker complain where null is returned by `renderHiddenItem` callback.
