### PR TITLE
Default right and left action values to 0

### DIFF
--- a/components/SwipeListView.js
+++ b/components/SwipeListView.js
@@ -231,10 +231,10 @@ class SwipeListView extends PureComponent {
                         this.props.rightActivationValue
                     }
                     leftActionValue={
-                        item.leftActionValue || this.props.leftActionValue
+                        item.leftActionValue || this.props.leftActionValue || 0
                     }
                     rightActionValue={
-                        item.rightActionValue || this.props.rightActionValue
+                        item.rightActionValue || this.props.rightActionValue || 0
                     }
                     initialLeftActionState={
                         item.initialLeftActionState ||


### PR DESCRIPTION
Fixes #495 
 
The below code is called with undefined if no value is provided for rightActionValue or leftActionValue.

iOS seems to cope with an undefined toValue but android crashes. 

See snack in related issue.

```
manuallySwipeRow(toValue, onAnimationEnd) {
        Animated.spring(this._translateX, {
            toValue,
...
```