### PR TITLE
swipeKey missing from types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -213,6 +213,7 @@ export class SwipeRow<T> extends Component<Partial<IPropsSwipeRow<T>>> {
 	closeRowWithoutAnimation: () => void;
 	render(): JSX.Element;
 	manuallySwipeRow: (toValue: number, onAnimationEnd?: () => void) => void;
+	swipeKey: string;
 }
 
 type IRenderListViewProps<T> = Omit<Omit<Omit<IPropsSwipeListView<T>, 'useFlatList'>, 'useSectionList'>, 'renderListView'>;


### PR DESCRIPTION
Thanks for submitting a pull request!

**Please confirm you have linted your code and fixed any issues:**

* [x] I ran `yarn run fix` on my PR and fixed any formatting issues

**Please provide information on what your PR achieves and any issues that it addresses:**

When using SwipeRow - swipeKey is not included in the typescript types.
