### PR TITLE
wrap React.PropsWithChildren

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,3 +1,4 @@
+import React = require('react');
 import { Component } from 'react';
 import { StyleProp, ViewStyle, ListView, NativeSyntheticEvent, NativeScrollEvent, ListRenderItemInfo, ListViewDataSource, SectionListProps, FlatListProps, GestureResponderEvent, PanResponderGestureState } from 'react-native';
 
@@ -207,7 +208,7 @@ interface IPropsSwipeRow<T> {
 	useNativeDriver: boolean;
 }
 
-export class SwipeRow<T> extends Component<Partial<IPropsSwipeRow<T>>> {
+export class SwipeRow<T> extends Component<Partial<React.PropsWithChildren<IPropsSwipeRow<T>>>> {
 	isOpen: boolean;
 	closeRow: () => void;
 	closeRowWithoutAnimation: () => void;


### PR DESCRIPTION
https://github.com/DefinitelyTyped/DefinitelyTyped/commit/55dc209ceb6dbcd59c4c68cc8dfb77faadd9de12
children is removed on React 18

Thanks for submitting a pull request!

**Please confirm you have linted your code and fixed any issues:**

* [x] I ran `yarn run fix` on my PR and fixed any formatting issues

execute result. None were relevant to this fix.

```
% yarn run fix                           
yarn run v1.22.10
$ yarn run prettier && yarn run lint
$ prettier --write --loglevel=warn "**/*.js"
$ eslint . --ext .js

/path/to/react-native-swipe-list-view/SwipeListExample/example.js
  46:29  warning  Inline style: { backgroundColor: "mode === type ? 'grey' : 'white'" }  react-native/no-inline-styles

/path/to/react-native-swipe-list-view/SwipeListExample/examples/actions.js
   84:40  warning  Inline style: { backgroundColor: 'lightgreen' }  react-native/no-inline-styles
   91:44  warning  Inline style: { backgroundColor: 'lightgreen' }  react-native/no-inline-styles
  142:44  warning  Inline style: { backgroundColor: 'lightgreen' }  react-native/no-inline-styles
  159:29  warning  Inline style: { flex: 1 }                        react-native/no-inline-styles

/path/to/react-native-swipe-list-view/SwipeListExample/examples/per_row_config.js
  35:31  warning  Missing radix parameter  radix

/path/to/react-native-swipe-list-view/SwipeListExample/examples/sectionlist.js
  21:31  warning  '_' is already declared in the upper scope  no-shadow

/path/to/react-native-swipe-list-view/bin/dev.js
  42:44  warning  'err' is already declared in the upper scope  no-shadow

/path/to/react-native-swipe-list-view/components/SwipeRow.js
  634:28  warning  Inline style: { zIndex: 2 }  react-native/no-inline-styles
  648:28  warning  Inline style: { zIndex: 2 }  react-native/no-inline-styles

/path/to/react-native-swipe-list-view/types/flowtypes.js
  2:0  warning  Unexpected unlimited 'eslint-disable' comment. Specify some rule names to disable  eslint-comments/no-unlimited-disable
  2:1  warning  ESLint rules are disabled but never reported                                       eslint-comments/no-unused-disable

✖ 12 problems (0 errors, 12 warnings)

✨  Done in 4.68s.
```

**Please provide information on what your PR achieves and any issues that it addresses:**

https://github.com/DefinitelyTyped/DefinitelyTyped/commit/55dc209ceb6dbcd59c4c68cc8dfb77faadd9de12
children is removed on React 18. So I add.