### PR TITLE
fix(docs): use custom domain as canonical site URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ list scrolls or when another row is opened.
 
 It also exports `<SwipeRow>` for using a swipeable row on its own.
 
-📖 **Full documentation:** <https://jemise111.github.io/react-native-swipe-list-view/>
+📖 **Full documentation:** <https://jessesessler.com/react-native-swipe-list-view/>
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "type": "git",
         "url": "git+https://github.com/jemise111/react-native-swipe-list-view.git"
     },
-    "homepage": "https://jemise111.github.io/react-native-swipe-list-view/",
+    "homepage": "https://jessesessler.com/react-native-swipe-list-view/",
     "bugs": {
         "url": "https://github.com/jemise111/react-native-swipe-list-view/issues"
     },

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -15,7 +15,10 @@ const config = {
     tagline: 'Swipeable-row FlatList / SectionList for React Native',
     favicon: 'img/favicon.png',
 
-    url: `https://${organizationName}.github.io`,
+    // Served via GitHub Pages on a custom domain (CNAME); `url` must be the
+    // canonical host so sitemap/canonical tags are correct. `organizationName`
+    // stays the GitHub org for repo/edit links.
+    url: 'https://jessesessler.com',
     baseUrl: `/${projectName}/`,
 
     organizationName,


### PR DESCRIPTION
The docs site is served via GitHub Pages on the **jessesessler.com** custom domain, but `docusaurus.config.js` still set `url` to the `jemise111.github.io` host. That made the generated **sitemap and canonical tags** point at the wrong origin (the github.io host only 301-redirects).

- `website/docusaurus.config.js`: `url` → `https://jessesessler.com` (baseUrl + organizationName unchanged)
- `README.md`: docs link → custom domain
- `package.json`: `homepage` → custom domain

Verified: `npm run build` in `website/` succeeds; `build/sitemap.xml` now uses `https://jessesessler.com/...`. Deploys on merge to master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)